### PR TITLE
fix: bring some fixes and improvements made on my fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,37 @@
 # OctoPrint-TuyaSmartplug
 
 Work based on [OctoPrint-TPLinkSmartplug](https://github.com/jneilliii/OctoPrint-TPLinkSmartplug) and [python-tuya](https://github.com/clach04/python-tuya).
-This plugin controlls [Tuya-based](https://en.tuya.com/) SmartPlugs.
 
-##  Screenshots
-![screenshot](screenshot.png)
+With this plugin you'll be able to control [Tuya-based](https://en.tuya.com/) SmartPlugs either directly from Octoprint Web interface or through GCODE commands<br>
+<br>
 
-![screenshot](settings.png)
+## Disclaimer
 
-![screenshot](plugeditor.png)
+Tuya is by far the most difficult IoT plataform that can be used to control devices by third-part software like this plugin, they require very specific information on the devices and change often their IoT Cloud Service.<br>
+Many user have given up on using Tuya devices with OctoPrint because of its difficulty, some changed to other brands, other dug deeper and changed the device firmware or completely changed the device microcontroler, literally soldering a new one.<br>
+If you, like me, only have Tuya devices and doesn't feel confortable on doing firmware flashes or resoldering, this plugin has a place on your OctoPrint instalation and its worth of your time configuring it. <br><br>
+This plugin still needs improvements on the code itself, UI, performance and other elements, so you are more then welcome to open [PullRequests](https://github.com/andrelucca/OctoTuya-SmartPlug/pulls) with code updates/fixes or [Issues](https://github.com/andrelucca/OctoTuya-SmartPlug/issues) regarding what needs to be fixed. <br>
+This is of course a side project of mine that unites two subjects that I like, so if you open a PR, Issue or a Discussion topic I'll answer as soon as I can, don't be angry if it takes more time than you think it should :). 
+
+## How it was tested?
+
+I tested all the plugin features using my Ender 3 V2 (Using original Marlin as Firmware that I configured and compiled) connected to the Octoprint v1.8.7. The Raspberry of my Octoprint is connected on the PSU of the printer, so if I power of the printer using the Tuya outlet it will also power-off the Raspberry (and will do it unsafely if I hadn't shutdown the Pi OS properly).
 
 ## Setup
 
 Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager)
 or manually using this URL:
 
-    https://github.com/ziirish/OctoPrint-TuyaSmartplug/archive/master.zip
+    https://github.com/ziirish/OctoPrint-TuyaSmartplug/archive/main.zip
 
+## Preparatory Work
 
-## Preparatory work
+All Tuya devices requires 2 infos in order to be controled by other software: `Device ID` and `Local Key`<br>
+And this is were the greater difficulty takes place. I made a full guide on how obtain this info in this project [Wiki](https://github.com/ziirish/OctoPrint-TuyaSmartplug/wiki) so make sure you follow it and have this infos before installing an using this plugin.
 
-In order to be able to interact with your Tuya smart plugs, you need to retrieve
-both the `Device ID` and the `Local Key`. You'll find information to get those
-in the [python-tuya wiki](https://github.com/clach04/python-tuya/wiki).
+## Configuration and Settings
 
-## Configuration
-
-Once installed go into settings and enter the ip address for your TP-Link Smartplug device. Adjust additional settings as needed.
-
-## Settings Explained
-- **IP**
-  - IP or hostname of the plug to control.
-- **Label**
-  - Label to use for title attribute on hover over button in navbar. Please note this settings is mandatory and should be unique across your plugs.
-- **Icon Class**
-  - Class name from [fontawesome](http://fontawesome.io/3.2.1/cheatsheet/) to use for icon on button.
-- **Device ID**
-  - Plug ID.
-- **Local Key**
-  - Local key to cypher data.
-- **Plug Slot**
-  - In case you have multiple slot, you can specify which one to interact with.
-- **Warning Prompt**
-  - Always warn when checked.
-- **Warn While Printing**
-  - Will only warn when printer is printing.
-- **Use Countdown Timers**
-  - Uses the plug's built in countdown timer rule to postpone the power on/off by configured delay in seconds.
-- **GCODE Trigger**
-  - When checked this will enable the processing of M80 and M81 commands from gcode to power on/off plug.  Syntax for gcode command is M80/M81 followed by hostname/ip.  For example if your plug is 192.168.1.2 your gcode command would be **M80 192.168.1.2**
-  - You can also use the custom gcode commands `@TUYAON` and `@TUYAOFF` followed by the IP address of the plug.  This option will only work for plugs with GCODE processing enabled.  For example if your plug is 192.168.1.2 your gcode command would be **@TUYAON 192.168.1.2**
-- **Auto Connect**
-  - Automatically connect to printer after plug is powered on.
-  - Will wait for number of seconds configured in **Auto Connect Delay** setting prior to attempting connection to printer.
-- **Auto Disconnect**
-  - Automatically disconnect printer prior to powering off the plug.
-  - Will wait for number of seconds configured in **Auto Disconnect Delay** prior to powering off the plug.
-- **Run System Command After On**
-  - When checked will run system command configured in **System Command On** setting after a delay in seconds configured in **System Command On Delay**.
-- **Run System Command Before Off**
-  - When checked will run system command configured in **System Command Off** setting after a delay in seconds configured in **System Command Off Delay**.
+All details on how to configure the plugin and how to change its settings according to your liking are in this project [Wiki](https://github.com/ziirish/OctoPrint-TuyaSmartplug/wiki)
 
 ## Support jneilliii Efforts
 Most of the code used in this plugin has been written by

--- a/octoprint_tuyasmartplug/static/js/tuyasmartplug.js
+++ b/octoprint_tuyasmartplug/static/js/tuyasmartplug.js
@@ -100,7 +100,7 @@ $(function() {
 					default:
 						new PNotify({
 							title: 'Tuya Smartplug Error',
-							text: 'Status ' + plug.currentState() + ' for ' + plug.ip() + '. Double check IP Address\\Hostname in tuyasmartplug Settings.',
+							text: 'Status ' + plug.currentState() + ' for ' + plug.ip() + '. Double check IP Address\\Device ID\\Local Key in Octoprint-TuyaSmartplug Settings.',
 							type: 'error',
 							hide: true
 							});

--- a/octoprint_tuyasmartplug/templates/tuyasmartplug_settings.jinja2
+++ b/octoprint_tuyasmartplug/templates/tuyasmartplug_settings.jinja2
@@ -54,36 +54,55 @@
 	<div class="modal-header">
 		<a href="#" class="close" data-dismiss="modal" aria-hidden="true">&times;</a>
 		<h3>Tuya Smartplug Editor</h3>
+		<h5>Check the plugin <a href="https://github.com/ziirish/OctoPrint-TuyaSmartplug/wiki/Plugin-Configurations-and-Settings#device-settings-screen" target="_blank">Wiki</a> for more details on this settings</h5>
 	</div>
 	<div class="modal-body">
 		<table class="table table-condensed">
 			<tr>
+				<td colspan="3" style="vertical-align: bottom, horizontal-align: center"><h4>Tuya Device Attributes</h4></td>
+			</tr>
+			<tr aria-rowspan="2"></tr>
+			<tr>
 				<td><div class="controls"><label class="control-label">{{ _('IP') }}</label><input type="text" class="input-block-level" data-bind="value: ip" /></div></td>
 				<td><div class="controls"><label class="control-label">{{ _('Label') }}</label><input type="text" class="input input-small" data-bind="value: label" required/></div></td>
-				<td><div class="controls"><label class="control-label"><a href="http://fontawesome.io/3.2.1/cheatsheet/" target="_blank">{{ _('Icon Class') }}</a></label><input type="text" class="input-block-level" data-bind="value: icon" /></div></td>
+				<td></td>
 			</tr>
 			<tr>
 				<td><div class="controls"><label class="control-label">{{ _('Device ID') }}</label><input type="text" class="input-block-level" data-bind="value: id" /></div></td>
-				<td><div class="controls"><label class="control-label">{{ _('Local Key') }}</label><input type="password" clas"input-block-level" data-bind="value: localKey" /></div></td>
-				<td><div class="controls"><label class="control-label">{{ _('Plug Slot') }}</label><input type="text" class="input input-small" data-bind="value: slot" /></div></td>
+				<td><div class="controls"><label class="control-label">{{ _('Local Key') }}</label><input type="password" class="input-block-level" data-bind="value: localKey" /></div></td>
+				<td><div class="controls"><label class="control-label">{{ _('Smart Outlet Slot') }}</label><input type="text" class="input input-small" data-bind="value: slot" /></div></td>
+			</tr>
+			<tr>
+				<td colspan="3" style="vertical-align: bottom, horizontal-align: center"><hr></td>
+			</tr>
+			<tr>
+				<td colspan="3" style="vertical-align: bottom, horizontal-align: center"><h4>Plugin Behavior</h4></td>
+			</tr>
+			<tr aria-rowspan="4"></tr>
+			<tr>
+				<td td colspan="2"><div class="controls"><label class="control-label"><a href="http://fontawesome.io/3.2.1/cheatsheet/" target="_blank">{{ _('Octoprint top bar Icon') }}</a></label><input type="text" class="input-block-level" data-bind="value: icon" /></div></td>
 			</tr>
 			<tr>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: displayWarning"/> Warning Prompt</label></div></td>
 				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: warnPrinting"/> Warn While Printing</label></div></td>
-				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: v33"/> Version 3.3</label></div></td>
+				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: v33"/> Use Protocol 3.3</label></div></td>
 			</tr>
 			<tr>
-				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: autoConnect"/> Auto Connect</label><input type="text" data-bind="value: autoConnectDelay,visible: autoConnect" class="input input-small" /></div></td>
-				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: autoDisconnect"/> Auto Disconnect</label><input type="text" data-bind="value: autoDisconnectDelay,visible: autoDisconnect" class="input input-small" /></div></td>
+				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: autoConnect"/> Auto Connect to Printer</label></div></td>
+				<td style="vertical-align: bottom"><div class="controls" data-bind="visible: autoConnect"><label class="control-label"> Delay </label><input type="text" data-bind="value: autoConnectDelay" class="input input-small" /> sec.</div></td>
 			</tr>
 			<tr>
-				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: useCountdownRules"/> Use Countdown Timers</label></div></td>
+				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: autoDisconnect"/> Auto Disconnect from Printer</label></div></td>
+				<td style="vertical-align: bottom"><div class="controls" data-bind="visible: autoDisconnect"><label class="control-label"> Delay </label><input type="text" data-bind="value: autoDisconnectDelay" class="input input-small" /> sec.</div></td>
+			</tr>
+			<tr>
+				<td><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: useCountdownRules"/> Use Device Countdown Timers</label></div></td>
 				<td></td>
 				<td></td>
 			</tr>
 			<tr data-bind="visible: useCountdownRules">
-				<td><div class="controls"><label class="control-label">{{ _('On Delay Countdown') }}</label><input type="text" data-bind="value: countdownOnDelay" class="input input-small" /></div></td>
-				<td><div class="controls"><label class="control-label">{{ _('Off Delay Countdown') }}</label><input type="text" data-bind="value: countdownOffDelay" class="input input-small" /></div></td>
+				<td><div class="controls"><label class="control-label">{{ _('On Timer') }}</label><input type="text" data-bind="value: countdownOnDelay" class="input input-small" /> sec.</div></td>
+				<td><div class="controls"><label class="control-label">{{ _('Off Timer') }}</label><input type="text" data-bind="value: countdownOffDelay" class="input input-small" /> sec.</div></td>
 				<td></td>
 			</tr>
 			<tr>
@@ -92,17 +111,17 @@
 				<td></td>
 			</tr>
 			<tr data-bind="visible: gcodeEnabled">
-				<td><div class="controls"><label class="control-label">{{ _('GCODE On Delay') }}</label><input type="text" data-bind="value: gcodeOnDelay" class="input input-small" /></div></td>
-				<td><div class="controls"><label class="control-label">{{ _('GCODE Off Delay') }}</label><input type="text" data-bind="value: gcodeOffDelay" class="input input-small" /></div></td>
+				<td><div class="controls"><label class="control-label">{{ _('GCODE On Delay') }}</label><input type="text" data-bind="value: gcodeOnDelay" class="input input-small" /> sec.</div></td>
+				<td><div class="controls"><label class="control-label">{{ _('GCODE Off Delay') }}</label><input type="text" data-bind="value: gcodeOffDelay" class="input input-small" /> sec.</div></td>
 				<td></td>
 			</tr>
 			<tr>
 				<td colspan="2" style="vertical-align: bottom"><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: sysCmdOn"/> Run System Command After On</label><input type="text" data-bind="value: sysRunCmdOn,visible: sysCmdOn" class="input-block-level" /></div></td>
-				<td style="vertical-align: bottom"><div class="controls" data-bind="visible: sysCmdOn"><label class="control-label">{{ _('Delay') }}</label><input type="text" data-bind="value: sysCmdOnDelay"  class="input input-small" /></div></td>
+				<td style="vertical-align: bottom"><div class="controls" data-bind="visible: sysCmdOn"><label class="control-label">{{ _('Delay') }}</label><input type="text" data-bind="value: sysCmdOnDelay"  class="input input-small" /> sec.</div></td>
 			</tr>
 			<tr>
 				<td colspan="2" style="vertical-align: bottom"><div class="controls"><label class="checkbox"><input type="checkbox" data-bind="checked: sysCmdOff"/> Run System Command Before Off</label><input type="text" data-bind="value: sysRunCmdOff,visible: sysCmdOff" class="input-block-level" /></div></td>
-				<td style="vertical-align: bottom"><div class="controls" data-bind="visible: sysCmdOff"><label class="control-label">{{ _('Delay') }}</label><input type="text" data-bind="value: sysCmdOffDelay"  class="input input-small" /></div></td>
+				<td style="vertical-align: bottom"><div class="controls" data-bind="visible: sysCmdOff"><label class="control-label">{{ _('Delay') }}</label><input type="text" data-bind="value: sysCmdOffDelay"  class="input input-small" /> sec.</div></td>
 			</tr>
 		</table>
 	</div>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_tuyasmartplug"
 plugin_name = "OctoPrint-TuyaSmartplug"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.0"
+plugin_version = "0.3.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
I just gained access as a maintainer in this plugin and I'm bringing some fixes and improvements that I made on my fork of it. This includes:
- Fix GCODE command processing, now using M80/M81 and G4
- Fix a bug on GCODE processing where the plugin only read the M80 command and where ignoring all the rest, being unable to Turn Off Tuya devices using it
- Minor improvements on plugin settings interface making it easier to understand
- A great [Wiki] (https://github.com/ziirish/OctoPrint-TuyaSmartplug/wiki) explaining how to make the plugin work, the required data from Tuya and how every setting on the plugin behaves

## For future releases:
Change the connection API to **tinytuya**, the current pytuya API in my tests didn't work, and I had a hard time configuring only one smart plug. On my fork I'm already using the tinytuya API and it's been working really good. 
Unfortunately to make this change I really need the help of the community testing the current version of the plugin and giving feedback if my experience with the current API is the same with other users.

*As this version uses the pytuya API  and wasn't upgraded yet it is a good option to test if solves the problema of the [Issue] (https://github.com/andrelucca/OctoTuya-SmartPlug/issues/4) opened in my fork*