### PR TITLE
Better debug for command exception

### DIFF
--- a/octoprint_tuyasmartplug/__init__.py
+++ b/octoprint_tuyasmartplug/__init__.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import absolute_import
 
+import traceback
 import octoprint.plugin
 from octoprint.server import user_permission
 import socket
@@ -310,7 +311,7 @@ class tuyasmartplugPlugin(
             return False
         except Exception as e:
             self._tuyasmartplug_logger.debug(
-                "Something went wrong while running the command " + str(e)
+                "Something went wrong while running the command " + str(e) + "\n" + traceback.format_exc()
             )
             return False
 


### PR DESCRIPTION
I am noticing that my smart plug isn't working here, but works find in Home Assistant and in the Smart Life app.
The plug generates this pretty scant debug output:
```
[2023-12-24 00:38:45,445] DEBUG: Checking status of Printer Power.
[2023-12-24 00:38:45,446] DEBUG: Sending command: info to Printer Power
[2023-12-24 00:38:45,530] DEBUG: Something went wrong while running the command ord() expected a character, but string of length 0 found

```
With the updated code, you see this instead, which is somewhat better, I think, because you can see where the issue arose:
```
[2023-12-24 00:40:22,337] DEBUG: Checking status of Printer Power.
[2023-12-24 00:40:22,339] DEBUG: Sending command: info to Printer Power
[2023-12-24 00:40:22,596] DEBUG: Something went wrong while running the command ord() expected a character, but string of length 0 found
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_tuyasmartplug/__init__.py", line 295, in sendCommand
    func()
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_tuyasmartplug/utils/pytuya.py", line 343, in status
    result = cipher.decrypt(result, False)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_tuyasmartplug/utils/pytuya.py", line 91, in decrypt
    return self._unpad(raw).decode("utf-8")
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_tuyasmartplug/utils/pytuya.py", line 107, in _unpad
    return s[: -ord(s[len(s) - 1 :])]
TypeError: ord() expected a character, but string of length 0 found
```

BTW, clearing the 3.3 protocol box eliminates the exception, but doesn't get the plug to work.

I notice that my plug is using **3.4** protocol, which looks like it's not supported, yet.  I can't tell if the plug _should_ work without the 3.3 box checked.

That's another issue, though.  :-)

